### PR TITLE
add auth server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,19 @@ services:
     ports:
       - "3030:3030"
 
+  # fxa-auth-server
+  auth:
+    command: node bin/key_server.js
+    environment:
+      NODE_ENV: "dev"
+      HOST: "0.0.0.0"
+    image: mozilla/fxa-auth-server
+    depends_on:
+      auth-db-mysql:
+        condition: service_healthy
+    ports:
+      - "9000:9000"
+
   # fxa-oauth-server
   oauth-web:
     command: node bin/server.js
@@ -31,6 +44,12 @@ services:
     image: mozilla/fxa-auth-db-mysql
     ports:
       - "8000:8000"
+    healthcheck:
+      test: curl --fail http://127.0.0.1:8000/ || exit 1
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
   # fxa-profile-server
   profile-web:
     command: node scripts/run_dev.js


### PR DESCRIPTION
@jbuck @seanmonstar so we have this thing where auth-server requires db to start first. 

I added these `depends_on` and a `healthcheck` options so db-mysql starts first. However it is not working. Ref: https://docs.docker.com/compose/compose-file/#healthcheck

Also see this: https://github.com/docker/compose/issues/374#issuecomment-284695410

Related for version 3 of compose files, this won't be supported:
> Basically, it won't be supported, you have to make your containers fault-tolerant instead of relying on docker-compose. ~ [docker/compose/issues/374#issuecomment-285156051](https://github.com/docker/compose/issues/374#issuecomment-285156051)

Which means we will need to patch the auth-server later on...
